### PR TITLE
Fix for BEL-220694

### DIFF
--- a/samples for testing/creating/callout.txt
+++ b/samples for testing/creating/callout.txt
@@ -1,7 +1,7 @@
 var osAutoDescr = 
 {
-  "FormatVersion":"2021-01-01",
-  "Annotations":
+  "formatVersion":"2021-01-01",
+  "annotations":
   [
     {
       "callout":

--- a/samples for testing/creating/centerline.txt
+++ b/samples for testing/creating/centerline.txt
@@ -1,10 +1,10 @@
 var osAutoDescr =
 {
-   "FormatVersion":"2021-01-01",
-   "Annotations":
+   "formatVersion":"2021-01-01",
+   "annotations":
    [
       {
-         "linetolinecenterline": {
+         "lineToLineCenterline": {
             "edge1": {
                "type": "Onshape::Reference::Edge",
                "uniqueId": "F424B",
@@ -19,7 +19,7 @@ var osAutoDescr =
          "type": "Onshape::Centerline::LineToLine"
       },
       {
-         "pointtopointcenterline": {
+         "pointToPointCenterline": {
             "point1": {
                "coordinate": [
                   12.284057964498157,
@@ -44,7 +44,7 @@ var osAutoDescr =
          "type": "Onshape::Centerline::PointToPoint"
       },
       {
-         "threepointcirclecenterline": {
+         "threePointCircleCenterline": {
             "logicalId": "h:10002632",
             "point1": {
                "coordinate": [
@@ -80,7 +80,7 @@ var osAutoDescr =
          "type": "Onshape::Centerline::ThreePointCircleCenterline"
       },
       {
-         "twopointcirclecenterline": {
+         "twoPointCircleCenterline": {
          "logicalId": "h:10002639",
          "centerPoint": {
             "coordinate": [

--- a/samples for testing/creating/dimension.txt
+++ b/samples for testing/creating/dimension.txt
@@ -1,10 +1,10 @@
 var osAutoDescr =
 {
-   "FormatVersion":"2021-01-01",
-   "Annotations":
+   "formatVersion":"2021-01-01",
+   "annotations":
    [
       {
-        "linetolineangulardimension": {
+        "lineToLineAngularDimension": {
           "arcPoint": {
             "coordinate": [
               3.1231382327754336,
@@ -76,7 +76,7 @@ var osAutoDescr =
         "type": "Onshape::Dimension::LineToLineAngular"
       },
       {
-        "threepointangulardimension": {
+        "threePointAngularDimension": {
           "center": {
             "coordinate": [
               3.1231382327754336,
@@ -136,7 +136,7 @@ var osAutoDescr =
         "type": "Onshape::Dimension::ThreePointAngular"
       },
       {
-        "radialdimension": {
+        "radialDimension": {
           "centerPoint": {
             "coordinate": [
               0.2800021171569824,
@@ -180,7 +180,7 @@ var osAutoDescr =
         "type": "Onshape::Dimension::Radial"
       },
       {
-        "diametricdimension": {
+        "diametricDimension": {
           "chordPoint": {
             "coordinate": [
               0.1933405012077314,

--- a/samples for testing/creating/geometrictolerance.txt
+++ b/samples for testing/creating/geometrictolerance.txt
@@ -1,10 +1,10 @@
 var osAutoDescr = 
 {
-  FormatVersion: '2021-01-01',
-  Annotations:
+  formatVersion: '2021-01-01',
+  annotations:
   [
     {
-      "geometrictolerance": {
+      "geometricTolerance": {
         "frames": [
           "{\\fDrawing Symbols Sans;◎}%%v{\\fDrawing Symbols Sans;∅}tol1{\\fDrawing Symbols Sans;Ⓜ}%%v%%v%%v%%v%%v\n",
           "{\\fDrawing Symbols Sans;⌖}%%vto2{\\fDrawing Symbols Sans;Ⓛ}%%v%%v%%v%%v%%v\n"
@@ -22,7 +22,7 @@ var osAutoDescr =
       "type": "Onshape::GeometricTolerance"
     },
     {
-      "geometrictolerance": {
+      "geometricTolerance": {
         "frames": [
           "{\\fDrawing Symbols Sans;◎}%%v{\\fDrawing Symbols Sans;∅}tol1{\\fDrawing Symbols Sans;Ⓜ}%%v%%v%%v%%v%%v\n",
           "{\\fDrawing Symbols Sans;⌖}%%vto2{\\fDrawing Symbols Sans;Ⓛ}%%v%%v%%v%%v%%v\n"
@@ -50,7 +50,7 @@ var osAutoDescr =
       "type": "Onshape::GeometricTolerance"
     },
     {
-      "geometrictolerance": {
+      "geometricTolerance": {
         "frames": [
           "{\\fDrawing Symbols Sans;◎}%%v{\\fDrawing Symbols Sans;∅}tol1{\\fDrawing Symbols Sans;Ⓜ}%%v%%v%%v%%v%%v\n",
           "{\\fDrawing Symbols Sans;⌖}%%vto2{\\fDrawing Symbols Sans;Ⓛ}%%v%%v%%v%%v%%v\n"

--- a/samples for testing/creating/inspectionSymbol.txt
+++ b/samples for testing/creating/inspectionSymbol.txt
@@ -3,11 +3,11 @@ For example, here used "noteTestWithoutLeader".
 
 var osAutoDescr = 
 {
-  "FormatVersion":"2021-01-01",
-  "Annotations":
+  "formatVersion":"2021-01-01",
+  "annotations":
   [
     {
-      "inspectionsymbol": {
+      "inspectionSymbol": {
         "borderShape": "Circle",
         "borderSize": 2,
         "logicalId": "h:1000058A",

--- a/samples for testing/creating/note.txt
+++ b/samples for testing/creating/note.txt
@@ -1,7 +1,7 @@
 var osAutoDescr =
 {
-  "FormatVersion":"2021-01-01",
-  "Annotations":
+  "formatVersion":"2021-01-01",
+  "annotations":
   [
     {
       "note": {

--- a/samples for testing/editing/inspectionSymbol.txt
+++ b/samples for testing/editing/inspectionSymbol.txt
@@ -1,11 +1,11 @@
 var osAutoDescr = 
 {
-  FormatVersion: '2021-01-01',
-  Annotations:
+  formatVersion: '2021-01-01',
+  annotations:
   [
     {
       type:"Onshape::InspectionSymbol",
-      inspectionsymbol : {
+      inspectionSymbol : {
         logicalId : "h:1000278D",
         number : 5
       }

--- a/samples for testing/instructions.txt
+++ b/samples for testing/instructions.txt
@@ -9,6 +9,6 @@ XeRequest.prototype.Promise( getXeDocument(), osAutoDescr, "OnshapeCreateAnnotat
 For editing use it: XeRequest.prototype.Promise( getXeDocument(), osAutoDescr, "OnshapeEditAnnotations")
 It will create/edit the annotations or report some error, if something goes wrong.
 
-Also there is separete drawing application extension that lives in separate frame and it also can create some annotations and export drawing json.
+Also there is separate drawing application extension that lives in separate frame and it also can create some annotations and export drawing json.
 
 


### PR DESCRIPTION
Mostly capitalization changes in the samples.
I tested the some of the edited samples using the approach described in instructions.txt where you copy the json into a variable in the developer console and then run an XeRequest to run it.  With a few small changes to view ids, etc, the samples worked properly, creating new annotations in the drawing.